### PR TITLE
Use the config file specified on command line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ if (!markdownFile) {
   process.exit(1);
 }
 
-const { options, plugins } = loadOptions();
+const { options, plugins } = loadOptions(program.config);
 const md = new MarkdownIt(options);
 plugins.forEach(plugin => {
   let package;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI wrapper for markdown-it allowing to set options and add plugins",
   "main": "./lib/index.js",
   "repository": "git@github.com:kennyx46/markdown-it-cli.git",


### PR DESCRIPTION
Hi @kennyx46!

The config command line option was specified but unused, this adds it.

Previously [submitted to the original repo](https://github.com/dsbert/markdown-it-cli/pull/1) (and accepted) but then I realized you own the npm package. 
